### PR TITLE
pass 'opts' to 'download'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ An optional options object parameter with download options. Options include:
 
 - `clone` - boolean default `false` - If true use `git clone` instead of an http download. While this can be a bit slower, it does allow private repositories to be used if the appropriate SSH keys are setup.
 
+If you also pass in other parameters, the parameters will be used as the [download](https://github.com/kevva/download) package options.
+
+For example,to download the local gitlab repository (usually the company's private gitlab), you need to bring `private_token`, otherwise you will get 404 error.
+
+```js
+download('flipxfx/download-git-repo-fixture', 'test/tmp', {
+  headers: {
+    'PRIVATE-TOKEN': 'your private token'
+  }
+}, function (err) {
+  console.log(err ? 'Error' : 'Success')
+})
+```
+
 #### callback
 The callback function as `function (err)`.
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,15 @@ function download (repo, dest, opts, fn) {
       }
     })
   } else {
-    downloadUrl(url, dest, { extract: true, strip: 1, mode: '666', headers: { accept: 'application/zip' } }).then(data => {
+    delete opts.clone
+    if (!opts.headers) {
+      opts.headers = {
+        accept: 'application/zip'
+      }
+    } else {
+      opts.headers.accept = 'application/zip'
+    }
+    downloadUrl(url, dest, Object.assign({ extract: true, strip: 1, mode: '666' }, opts)).then(data => {
       fn()
     }).catch(err => {
       fn(err)


### PR DESCRIPTION
For example,to download the local gitlab repository (usually the company's private gitlab), need to bring `private_token`, otherwise you will get 404 error.

This feature will be:

```js
download('flipxfx/download-git-repo-fixture', 'test/tmp', {
  headers: {
    'PRIVATE-TOKEN': 'your private token'
  }
}, function (err) {
  console.log(err ? 'Error' : 'Success')
})
```

So, need to pass the options down. the options will pass to [download](https://github.com/kevva/download), then pass to [got](https://github.com/sindresorhus/got).

